### PR TITLE
Correcting error when app dir has a hyphen (-) and/or period (.) in it.

### DIFF
--- a/vendors/shells/migration.php
+++ b/vendors/shells/migration.php
@@ -495,9 +495,9 @@ TEXT;
 		}
 		require_once $file;
 
-		$name = Inflector::camelize($type) . 'Schema';
+		$name = Inflector::camelize(Inflector::slug($type)) . 'Schema';
 		if ($type == 'app' && !class_exists($name)) {
-			$name = Inflector::camelize($this->params['app']) . 'Schema';
+			$name = Inflector::camelize(Inflector::slug($this->params['app'])) . 'Schema';
 		}
 
 		$plugin = ($type === 'app') ? null : $type;


### PR DESCRIPTION
i.e. "PHP Fatal error:  Class 'Website-1.0Schema' not found"
Now escaping schema class name the same way the cake schema shell does it.
