### PR TITLE
Changed the regex to be case insensitive

### DIFF
--- a/tests/cases/vendors/shells/migration.test.php
+++ b/tests/cases/vendors/shells/migration.test.php
@@ -726,12 +726,12 @@ TEXT;
 		// Adding other migration to it
 		$this->Shell->expectCallCount('err', 1);
 		$this->Shell->setReturnValueAt(2, 'in', '002-invalid-name');
-		$this->Shell->setReturnValueAt(3, 'in', '002 create some sample_data');
+		$this->Shell->setReturnValueAt(3, 'in', '002 created table for UserProfile model');
 		$this->Shell->setReturnValueAt(4, 'in', 'n');
 
-		$this->assertFalse(file_exists(TMP . 'tests' . DS . '002_create_some_sample_data.php'));
+		$this->assertFalse(file_exists(TMP . 'tests' . DS . '002_created_table_for_UserProfile_model.php'));
 		$this->Shell->generate();
-		$this->assertTrue(file_exists(TMP . 'tests' . DS . '002_create_some_sample_data.php'));
+		$this->assertTrue(file_exists(TMP . 'tests' . DS . '002_created_table_for_UserProfile_model.php'));
 
 		$result = file_get_contents(TMP . 'tests' . DS . 'map.php');
 		$pattern = <<<TEXT
@@ -740,7 +740,7 @@ TEXT;
 	1 => array\(
 		'001_initial_schema' => 'M([a-zA-Z0-9]+)'\),
 	2 => array\(
-		'002_create_some_sample_data' => 'M([a-zA-Z0-9]+)'\),
+		'002_created_table_for_UserProfile_model' => 'M([a-zA-Z0-9]+)'\),
 \);
 \?>$/
 TEXT;
@@ -748,7 +748,7 @@ TEXT;
 
 		// Remove created files
 		@unlink(TMP . 'tests' . DS . '001_initial_schema.php');
-		@unlink(TMP . 'tests' . DS . '002_create_some_sample_data.php');
+		@unlink(TMP . 'tests' . DS . '002_created_table_for_UserProfile_model.php');
 		@unlink(TMP . 'tests' . DS . 'map.php');
 	}
 

--- a/vendors/shells/migration.php
+++ b/vendors/shells/migration.php
@@ -211,7 +211,7 @@ class MigrationShell extends Shell {
 	public function generate() {
 		while (true) {
 			$name = $this->in(__d('migrations', 'Please enter the descriptive name of the migration to generate:', true));
-			if (!preg_match('/^([a-z0-9_]+|\s)+$/', $name)) {
+			if (!preg_match('/^([a-z0-9_]+|\s)+$/i', $name)) {
 				$this->out('');
 				$this->err(sprintf(__d('migrations', 'Migration name (%s) is invalid. It must only contain alphanumeric characters.', true), $name));
 			} else {


### PR DESCRIPTION
I updated the code to be case insensitive when generating the migrations names and also updated the tests to include it, tests fails without the fix.

There is no real reason to be case sensitive, in fact the error message or the instructions does not mention that. Also it does improve the readability in some cases, for example when using "UserProfile" instead of "userprofile" as is in the test. 
