### PR TITLE
Fixed bug when trying to change the field type (CakeMigration).

### DIFF
--- a/libs/model/cake_migration.php
+++ b/libs/model/cake_migration.php
@@ -350,8 +350,12 @@ class CakeMigration extends Object {
 						));
 						break;
 					case 'change':
+						$def = array_merge($tableFields[$field], $col);
+						if (!empty($def['length']) && !empty($col['type']) && substr($col['type'], 0, 4) == 'date') {
+							$def['length'] = null;
+						}
 						$sql = $this->db->alterSchema(array(
-							$table => array('change' => array($field => array_merge($tableFields[$field], $col)))
+							$table => array('change' => array($field => $def))
 						));
 						break;
 					case 'rename':

--- a/tests/cases/libs/model/cake_migration.test.php
+++ b/tests/cases/libs/model/cake_migration.test.php
@@ -353,6 +353,44 @@ class CakeMigrationTest extends CakeTestCase {
 	}
 
 /**
+ * testAlterFieldLength method
+ *
+ * @access public
+ * @return void
+ */
+	function testAlterFieldLength() {
+		$this->loadFixtures('User', 'Post');
+		$model = new Model(array('table' => 'posts', 'ds' => 'test_suite'));
+
+		$migration = new TestCakeMigration(array(
+			'up' => array(
+				'alter_field' => array(
+					'posts' => array('created' => array('type' => 'integer', 'length' => 11))
+				)
+			),
+			'down' => array(
+				'alter_field' => array(
+					'posts' => array('created' => array('type' => 'datetime'))
+				)
+			)
+		));
+
+		$fields = $this->db->describe($model);
+		$this->assertEqual($fields['created']['type'], 'datetime');
+		$this->assertNull($fields['created']['length']);
+
+		$this->assertTrue($migration->run('up'));
+		$fields = $this->db->describe($model);
+		$this->assertEqual($fields['created']['type'], 'integer');
+		$this->assertEqual($fields['created']['length'], 11);
+
+		$this->assertTrue($migration->run('down'));
+		$fields = $this->db->describe($model);
+		$this->assertEqual($fields['created']['type'], 'datetime');
+		$this->assertNull($fields['created']['length']);
+	}
+
+/**
  * testAlterAndRenameField method
  *
  * @access public


### PR DESCRIPTION
If the current field contains length, CakeMigration will try to force the length on the new field as well. It fails when changing from integer to datetime for example.

Please, take a look into https://github.com/CakeDC/migrations/pull/24 before doing it.
