### PR TITLE
Fixed bug when trying to change the field type (Shell).

### DIFF
--- a/tests/cases/vendors/shells/migration.test.php
+++ b/tests/cases/vendors/shells/migration.test.php
@@ -594,6 +594,35 @@ TEXT;
 			)
 		);
 		$this->assertEqual($result, $expected);
+
+		// Change field with/out length
+		$oldTables = array('users' => $this->tables['users']);
+		$newTables = array('users' => array());
+		$oldTables['users']['last_login'] = array('type' => 'integer', 'null' => false, 'length' => 11);
+
+		$comparison = array(
+			'users' => array('change' => array(
+				'last_login' => array('type' => 'datetime', 'null' => false),
+			))
+		);
+		$result = $this->Shell->fromComparison(array(), $comparison, $oldTables, $newTables);
+		$expected = array(
+			'up' => array(
+				'alter_field' => array(
+					'users' => array(
+						'last_login' => array('type' => 'datetime', 'null' => false, 'length' => null)
+					)
+				)
+			),
+			'down' => array(
+				'alter_field' => array(
+					'users' => array(
+						'last_login' => array('type' => 'integer', 'null' => false, 'length' => 11)
+					)
+				)
+			)
+		);
+		$this->assertEqual($result, $expected);
 	}
 
 /**

--- a/vendors/shells/migration.php
+++ b/vendors/shells/migration.php
@@ -464,6 +464,11 @@ TEXT;
 						$migration['down']['drop_field'][$table]['indexes'] = array_keys($indexes['indexes']);
 					}
 				} else if ($type == 'change') {
+					foreach ($fields as $name => $col) {
+						if (!empty($oldTables[$table][$name]['length']) && substr($col['type'], 0, 4) == 'date') {
+							$fields[$name]['length'] = null;
+						}
+					}
 					$migration['up']['alter_field'][$table] = $fields;
 					$migration['down']['alter_field'][$table] = array_intersect_key($oldTables[$table], $fields);
 				} else {


### PR DESCRIPTION
If the current field contains length, CakeMigration will try to force the length on the new field as well. It fails when changing from integer to datetime for example.

Please, take a look into https://github.com/CakeDC/migrations/pull/23 before doing it.
