### PR TITLE
Show help instead of trying to run() as default action.  This fixes the ...

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -140,7 +140,7 @@ class MigrationShell extends Shell {
  * @return void
  */
 	public function main() {
-		$this->run();
+		$this->out($this->getOptionParser()->help());
 	}
 
 /**


### PR DESCRIPTION
...option parser issue of passing boolean flags before the subcommand.  Example: <pre>cake Migrations.migration -f generate</pre> will now work as expected.  Run is a subcommand, and described in the help to run it as such, not by default.
