### PR TITLE
if the migration class names are longer than 33 characters, running migr...

### DIFF
--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -184,6 +184,11 @@ class MigrationVersion {
 					$mapping[$version]['migrated'] = $migrated[$version];
 				}
 			} else {
+				// the class in schema_migrations is set to VARCHAR 33, so we need to substr
+				// in order to retrieve the proper class value from database
+				// regardless the actual classname
+				$class = substr($class, 0, 33);
+				
 				if (isset($migrated[$class])) {
 					$mapping[$version]['migrated'] = $migrated[$class];
 				} elseif (isset($bcMapping[$class]) && !empty($migrated[$bcMapping[$class]])) {


### PR DESCRIPTION
...ations up or all will always prompt running migrated migrations

This also fixes the issue I raised in https://github.com/CakeDC/migrations/issues/66
#66
