### PR TITLE
Migration file to change class name length, friendly warning in the console for too-long description

### DIFF
--- a/Config/Migration/003_increase_class_name_length.php
+++ b/Config/Migration/003_increase_class_name_length.php
@@ -1,0 +1,58 @@
+<?php
+class IncreaseClassNameLength extends CakeMigration {
+
+/**
+ * Migration description
+ *
+ * @var string
+ * @access public
+ */
+	public $description = 'Increase the maximum length of class names.';
+
+/**
+ * Actions to be performed
+ *
+ * @var array $migration
+ * @access public
+ */
+	public $migration = array(
+		'up' => array(
+			'alter_field' => array(
+				'schema_migrations' => array(
+					'class' => array('type' => 'string', 'null' => false, 'default' => NULL, 'length' => 255, 'name' => 'class')
+				)
+			)
+		),
+		'down' => array(
+			'alter_field' => array(
+				'schema_migrations' => array(
+					'class' => array('type' => 'string', 'null' => false, 'default' => NULL, 'length' => 33, 'name' => 'class')
+				)
+			)
+		)
+	);
+
+/**
+ * Before migration callback
+ *
+ * @param string $direction, up or down direction of migration process
+ * @return boolean Should process continue
+ * @access public
+ */
+	public function before($direction) {
+		return true;
+	}
+
+/**
+ * After migration callback
+ *
+ * @param string $direction, up or down direction of migration process
+ * @return boolean Should process continue
+ * @access public
+ */
+	public function after($direction) {
+		return true;
+	}
+}
+
+?>

--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -328,6 +328,9 @@ class MigrationShell extends Shell {
 			if (!preg_match('/^([A-Za-z0-9_]+|\s)+$/', $name) || is_numeric($name[0])) {
 				$this->out('');
 				$this->err(__d('Migrations', 'Migration name (%s) is invalid. It must only contain alphanumeric characters and start with a letter.', $name));
+			} elseif (strlen($name) > 255) {
+				$this->out('');
+				$this->err(__d('Migrations', 'Migration name (%s) is invalid. It cannot be longer than 255 characters.', $name));
 			} else {
 				$name = str_replace(' ', '_', trim($name));
 				break;


### PR DESCRIPTION
Created a migration file to change the class name field length to 255. Added a warning in the console if the user inputs a description longer than 255 characters.

I added a new migrations file instead of editing 002 so that existing users of the Migrations plugin can just run `Console/cake Migrations.migration -p Migrations` to have the field changed.
