### PR TITLE
'time' field causes errors

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -350,7 +350,7 @@ class CakeMigration extends Object {
 						break;
 					case 'change':
 						$def = array_merge($tableFields[$field], $col);
-						if (!empty($def['length']) && !empty($col['type']) && substr($col['type'], 0, 4) == 'date') {
+						if (!empty($def['length']) && !empty($col['type']) && (substr($col['type'], 0, 4) == 'date' || substr($col['type'], 0, 4) == 'time')) {
 							$def['length'] = null;
 						}
 						$sql = $this->db->alterSchema(array(


### PR DESCRIPTION
Commit message: Remove the 'length' attribute if we are altering a field to a time field.

I couldn't reopen issue #10, but this is directly related to it. CakePHP now supports time fields in their schema (since [at least 1.3](http://book.cakephp.org/1.3/view/1003/Data-Type-Associations-by-Database)), but Migrations tries to give the time field a length.

The error looks something like this:
`Error: SQLSTATE[42000]: Syntax error or access violation: 1064
You have an error in your SQL syntax;
check the manual that corresponds to your MySQL server version for the right syntax
to use near '(11) NOT NULL' at line 2`

And is caused by an SQL query such as:
`ALTER TABLE `dev`.`times` 
    CHANGE `start_time` `start_time` time(11) NOT NULL;`

The fix for removing the length when altering the 'time' field is the same as existing code that removes the length when altering a 'date' field.
