### PR TITLE
Enable rename table on Postgres and others

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -294,11 +294,7 @@ class CakeMigration extends Object {
 				);
 			}
 
-			if($this->db instanceof MySQL) {
-				$sql = 'RENAME TABLE ' . $this->db->fullTableName($oldName) . ' TO ' . $this->db->fullTableName($newName) . ';';
-			} else {
-				$sql = 'ALTER TABLE ' . $oldName . ' RENAME TO ' . $newName . ';';
-			}
+			$sql = 'ALTER TABLE ' . $this->db->fullTableName($oldName) . ' RENAME TO ' . $newName . ';';
 
 			$this->_invokeCallbacks('beforeAction', 'rename_table', array('old_name' => $oldName, 'new_name' => $newName));
 			if (@$this->db->execute($sql) === false) {
@@ -363,7 +359,6 @@ class CakeMigration extends Object {
 						));
 						break;
 					case 'rename':
-						die("ae");
 						$sql = $this->db->alterSchema(array(
 							$table => array('change' => array($field => array_merge($tableFields[$field], array('name' => $col))))
 						));


### PR DESCRIPTION
Current implementation of rename_table doesn't work on Postgres (see 'docs' below) because MySQL have a different syntax.

Oracle and SQL Server have the same syntax of Postgres (links below).

Postgres: http://www.postgresql.org/docs/9.1/static/sql-altertable.html
Oracle: http://www.dba-oracle.com/t_alter_table_rename.htm
SQL Server: http://stackoverflow.com/questions/5335528/sql-server-alter-rename-table
