### PR TITLE
Fixed a bug when Config 'pluginPaths' was not defined

### DIFF
--- a/libs/migration_version.php
+++ b/libs/migration_version.php
@@ -273,6 +273,9 @@ class MigrationVersion {
 			$found = true;
 		} else {
 			$paths = Configure::read('pluginPaths');
+			if (!is_array($paths) || empty($paths)) {
+				$paths = array();
+			}
 			foreach ($paths as $path) {
 				if (file_exists($path . $type) && is_dir($path . $type)) {
 					if (!file_exists($path . $type . DS . 'config' . DS . 'migrations' . DS . $name . '.php')) {


### PR DESCRIPTION
If you didn't define this configuraiton, you got a wanring about foreach on a non-array every run.
This just ensures the variable is an array.
