### PR TITLE
Fix an isssue when using a migration with a different datasource 

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -446,10 +446,7 @@ class CakeMigration extends Object {
 		ClassRegistry::flush();
 
 		// Refresh the model, in case something changed
-		$options = array(
-			'class' => 'Migrations.SchemaMigration',
-			'ds' => $this->connection);
-		$this->Version->Version =& ClassRegistry::init($options);
+		$this->Version->initVersion();
 	}
 
 /**

--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -59,13 +59,24 @@ class MigrationVersion {
 			$this->connection = $options['connection'];
 		}
 
+		$this->initVersion();
+
+		if (!isset($options['autoinit']) || $options['autoinit'] !== false) {
+			$this->__initMigrations();
+		}
+	}
+
+/**
+ * get a new SchemaMigration instance
+ *
+ * @return void
+ */
+
+	public function initVersion() {
 		$this->Version = ClassRegistry::init(array(
 			'class' => 'Migrations.SchemaMigration',
 			'ds' => $this->connection
 		));
-		if (!isset($options['autoinit']) || $options['autoinit'] !== false) {
-			$this->__initMigrations();
-		}
 	}
 
 /**


### PR DESCRIPTION
The issue was implied by the use of a duplicated code.

At the end of _clearCache() method, the code is the same than the one in MigrationVersion::__construct() method.

Indeed in CakeMigration::_clearCache(), the new instance of Migrations.SchemaMigration, use the CakeMigration::connection attribute instead of MigrationVersion one.
