### PR TITLE
Fix an isssue when using a migration with another datasource than the default one.

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -507,11 +507,9 @@ class CakeMigration extends Object {
 		ClassRegistry::flush();
 
 		// Refresh the model, in case something changed
-		$options = array(
-			'class' => 'Migrations.SchemaMigration',
-			'ds' => $this->connection);
-		$this->Version->Version =& ClassRegistry::init($options);
-		$this->Version->Version->setDataSource($this->connection);
+		if ($this->Version instanceof MigrationVersion) {
+			$this->Version->initVersion();
+		}
 	}
 
 /**

--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -59,14 +59,25 @@ class MigrationVersion {
 			$this->connection = $options['connection'];
 		}
 
+		$this->initVersion();
+
+		if (!isset($options['autoinit']) || $options['autoinit'] !== false) {
+			$this->__initMigrations();
+		}
+	}
+
+/**
+ * get a new SchemaMigration instance
+ *
+ * @return void
+ */
+
+	public function initVersion() {
 		$this->Version = ClassRegistry::init(array(
 			'class' => 'Migrations.SchemaMigration',
 			'ds' => $this->connection
 		));
 		$this->Version->setDataSource($this->connection);
-		if (!isset($options['autoinit']) || $options['autoinit'] !== false) {
-			$this->__initMigrations();
-		}
 	}
 
 /**


### PR DESCRIPTION
Below is an illustration of the side effect issue fixed in this PR. Since the clearCache method was not really tested we have not spend further time recreating tests for it.

Please also note that the develop branch is outdated and some commits in master have not been backported to it (which is weird for an integration branch).
# To reproduce the issue

One can highlight the problem with running the following migration:

``` php
<?php
class AddFooField extends CakeMigration {

    public $connection = 'anotherConnection';

    public $migration = array(
        'up' => array(
            'create_field' => array(
                'config' => array(
                    'foo' => array('type' => 'string', 'null' => false, 'length' => 255)
                ),
            ),
        ),
        'down' => array(
            'drop_field' => array(
                'foo' => array('bar')
            ),
        ),
    );

    public function before($direction) {        
        return true;
    }

    public function after($direction) {
        return true;
    }

}
```
