### PR TITLE
enable CakeMigration::connection

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -504,11 +504,12 @@ class CakeMigration extends Object {
 		ClassRegistry::flush();
 
 		// Refresh the model, in case something changed
+		$useDbConfig = $this->Version->Version->useDbConfig;
 		$options = array(
 			'class' => 'Migrations.SchemaMigration',
-			'ds' => $this->connection);
+			'ds' => $useDbConfig);
 		$this->Version->Version =& ClassRegistry::init($options);
-		$this->Version->Version->setDataSource($this->connection);
+		$this->Version->Version->setDataSource($useDbConfig);
 	}
 
 /**

--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -217,7 +217,7 @@ class MigrationVersion {
 		}
 
 		$defaults = array(
-			'connection' => $this->connection
+			'connection' => null
 		);
 		$options = array_merge($defaults, $options);
 		return new $class($options);
@@ -333,6 +333,7 @@ class MigrationVersion {
 
 			list($name, $class) = each($map[1]);
 			$migration = $this->getMigration($name, $class, 'Migrations');
+			$migration->Version = $this;
 			$migration->run('up');
 			$this->setVersion(1, 'Migrations');
 		}


### PR DESCRIPTION
CakeMigration::connection will be overwritten and the set-up value does not become effective.
