### PR TITLE
bugfix pluginPaths configuration missing in 1.3

### DIFF
--- a/vendors/shells/migration.php
+++ b/vendors/shells/migration.php
@@ -635,6 +635,10 @@ TEXT;
 			return APP;
 		} else {
 			$paths = Configure::read('pluginPaths');
+			if (empty($paths)) {
+				Configure::write('pluginPaths', array(APP.'plugins/'));
+				$paths = Configure::read('pluginPaths');
+			}
 			foreach ($paths as $path) {
 				if (file_exists($path . $type) && is_dir($path . $type)) {
 					return $path . $type . DS;


### PR DESCRIPTION
again, i see the pluginPaths configuration is missing, and this time I've fixed it by defining a reasonable default array instead of an empty array.
went ahead and assigned to a configuration so we are not re-defaulting for multiple requests.

related to previous commit 5661f98e3ea4eb991ffcd615bcc46c46a46f8932
https://github.com/CakeDC/migrations/commit/5661f98e3ea4eb991ffcd615bcc46c46a46f8932
