### PR TITLE
Fix php strict standards - remove reference assignment

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -507,7 +507,7 @@ class CakeMigration extends Object {
 		$options = array(
 			'class' => 'Migrations.SchemaMigration',
 			'ds' => $this->connection);
-		$this->Version->Version =& ClassRegistry::init($options);
+		$this->Version->Version = ClassRegistry::init($options);
 		$this->Version->Version->setDataSource($this->connection);
 	}
 


### PR DESCRIPTION
Branch name is miss leading. But patch removes an " Only variables should be assigned by reference PHP 5.4" error.
