### PR TITLE
Fixed a Set::extract to use the correct alias and get correct plugin names

### DIFF
--- a/Config/Migration/002_convert_version_to_class_names.php
+++ b/Config/Migration/002_convert_version_to_class_names.php
@@ -113,7 +113,7 @@ class ConvertVersionToClassNames extends CakeMigration {
  * @return void 
  */
 	public function checkPlugins() {
-		$types = Set::extract('/Version/type', $this->records);
+		$types = Set::extract('/' . $this->Version->Version->alias . '/type', $this->records);
 		$types = $plugins = array_unique($types);
 
 		// Remove app from it


### PR DESCRIPTION
Since the ghost model class is "SchemaMigration" the model alias is also "SchemaMigration".

Since the Migration did a `Set::extract` on an invalid alias (Version) it did not detect any old type in checkPlugins.
This commit fixes the Migration.
