### PR TITLE
Rename table didn't use table prefix

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -322,7 +322,7 @@ class CakeMigration extends Object {
 				);
 			}
 
-			$sql = 'ALTER TABLE ' . $this->db->fullTableName($oldName) . ' RENAME TO ' . $newName . ';';
+			$sql = 'ALTER TABLE ' . $this->db->fullTableName($oldName) . ' RENAME TO ' . $this->db->fullTableName($newName) . ';';
 
 			$this->_invokeCallbacks('beforeAction', 'rename_table', array('old_name' => $oldName, 'new_name' => $newName));
 			if (@$this->db->execute($sql) === false) {


### PR DESCRIPTION
In CakeMigration, alter table did not call fullTableName. 
This was causing lost of table prefix.
