### PR TITLE
Error with CakePHP 2.3.0

### DIFF
--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -59,6 +59,7 @@ class MigrationVersion {
 			$this->connection = $options['connection'];
 		}
 
+    App::uses('ClassRegistry', 'Utility');
 		$this->Version = ClassRegistry::init(array(
 			'class' => 'Migrations.SchemaMigration',
 			'ds' => $this->connection


### PR DESCRIPTION
Migrations failed in CakePHP 2.3.0.
The error message is 

Fatal error: Class 'ClassRegistry' not found in {$app_path}/Plugin/Migrations/Lib/MigrationVersion.php on line 62.

So, I added code to import ClassRegistry.
It works fine.
