### PR TITLE
Update Lib/MigrationVersion.php

### DIFF
--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -19,6 +19,7 @@ App::uses('CakeMigration', 'Migrations.Lib');
 App::uses('ConnectionManager', 'Model');
 App::uses('Inflector', 'Utility');
 App::uses('Folder', 'Utility');
+App::uses('ClassRegistry', 'Utility');
 
 /**
  * Migration version management.


### PR DESCRIPTION
This is to fix the bug I had when I execute `Console/cake Migrations.migration run all -p Migrations

`

Fatal error: Class 'ClassRegistry' not found in APP/Plugin/Migrations/Lib/MigrationVersion.php on line 62
