### PR TITLE
Update Lib/CakeMigration.php

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -507,7 +507,7 @@ class CakeMigration extends Object {
 		$options = array(
 			'class' => 'Migrations.SchemaMigration',
 			'ds' => $this->connection);
-		$this->Version->Version =& ClassRegistry::init($options);
+		$this->Version->Version = ClassRegistry::init($options);
 		$this->Version->Version->setDataSource($this->connection);
 	}
 


### PR DESCRIPTION
This is to fix errors when I run `Console/cake Migrations.migration run all -p Migrations
`

The errors are:
## Cake Migration Shell

Strict Error: Only variables should be assigned by reference in [APP/Plugin/Migrations/Lib/CakeMigration.php, line 510]

Strict Error: Only variables should be assigned by reference in [APP/Plugin/Migrations/Lib/CakeMigration.php, line 510]

Strict Error: Only variables should be assigned by reference in [APP/Plugin/Migrations/Lib/CakeMigration.php, line 510]

Running migrations:
All migrations have completed.

The Strict Error has to do with PHP 5.4

From php's manual on assignment by reference: http://php.net/manual/en/language.operators.assignment.php

As of PHP 5, the new operator returns a reference automatically, so assigning the result of new by reference results in an E_DEPRECATED message in PHP 5.3 and later, and an E_STRICT message in earlier versions.
