### PR TITLE
Fixed fatal error on non-loaded plugins

### DIFF
--- a/Lib/Panel/MigrationsPanel.php
+++ b/Lib/Panel/MigrationsPanel.php
@@ -74,7 +74,7 @@ class MigrationsPanel extends DebugPanel {
 		$v = new MigrationVersion();
 		$map = $migrations = array();
 
-		$migrations = Hash::merge(array('app'), App::objects('plugin'));
+		$migrations = Hash::merge(array('app'), CakePlugin::loaded());
 		foreach ($migrations as $plugin) {
 			try {
 				$map[$plugin] = array(


### PR DESCRIPTION
DebugKit panel throws an error if you try to read migrations for plugins
which are not loaded using CakePlugin::load().

Tested on clean CakePHP 2.3.0 and 2.2.1 installs.

Changed the code to load migrations only for loaded plugins.

To repeat the error:

Use CakePHP 2.3
Setup DebugKit and Migrations panel (AppController::$components => DebugKit.Toolbar => panels ['Migrations.migrations'])
Put any Plugin in app/Plugin/ but don't load it in bootstrap.
