### PR TITLE
Add support for `add_index` and `drop_index` migration methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -243,6 +243,27 @@ Likewise, if you want to drop an index then you need to drop the field including
 		)
 	)
 
+#### Add an Index ####
+
+You can add an index to an existing field by using syntax like:
+
+   'add_index' => array(
+       array('table' => 'animals', 'fields' => array('name', 'age'), 'name' => 'your_index_name', 'unique' => false)
+   )
+
+Note that `name` is optional and if not supplied the Plugin will automatically generate an index name based on the table and the columns in the index. A potential issue is that some databases (MySQL, Postgres) have a maximum index name of 64 characters. If the auto-generated name of the index is longer than 64 characters than the migration will fail with an error and description. In this case you will need to supply the `name` parameter and provide a valid and appropriate index name.
+
+#### Drop an Index ####
+
+Dropping an existing index is straight-forward:
+
+   'drop_index' => array(
+       array('table' => 'animals', 'fields' => array('name', 'age'), 'name' => 'your_index_name')
+   )
+
+Note that if you created your index using a custom `name` (e.g. in the `add_index` definition) then you will need to provide this same name in the `name` parameter.
+  	
+
 ## Callbacks ##
 
 You can make use of callbacks in order to execute extra operations, for example, to fill tables with predefined data, you can even use the shell to ask the user for data that is going to be inserted.


### PR DESCRIPTION
I see that the only way to add an index to an existing table is to use the `alterIndex` method but this is **CRAZY** because it requires you to first drop the field and re-add it. 

This is crazy because you will lose whatever data is in that field.

This pull-request adds explicit migration methods for `add_index` and the complementary `drop_index`. There is also an updated `README` with usage of these new methods.

I see in the `README` this line: 

`Unit tests for new features and issues detected are mandatory to keep quality high.`

But I don't see any existing unit tests that I can reference for how to write a new one.
