### PR TITLE
Removing legacy reset/restore methods and array key

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -182,7 +182,6 @@ class MigrationShell extends AppShell {
 			$options['direction'] = 'up';
 		} else if (isset($this->args[0]) && $this->args[0] == 'reset') {
 			$options['version'] = 0;
-			$options['reset'] = true;
 			$options['direction'] = 'down';
 		} else {
 			$options = $this->_promptVersionOptions($mapping, $latestVersion);

--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -316,32 +316,6 @@ class MigrationVersion {
 	}
 
 /**
- * Resets the migration to 0.
- * @param $type string type of migration being ran
- * @return void
- */
-	protected function resetMigration($type) {
-		$options['type'] = $type;
-		$options['version'] = 0;
-		$options['reset'] = true;
-		$options['direction'] = 'down';
-		$this->run($options);
-	}
-
-/**
- * Runs migration to the last well known version defined by $toVersion.
- * @param $toVersion string name of the version where the migration will run up to.
- * @param $type string type of migration being ran.
- * @return void
- */
-	protected function restoreMigration($toVersion, $type) {
-		$options['type'] = $type;
-		$options['direction'] = 'up';
-		$options['version'] = $toVersion;
-		$this->run($options);
-	}
-
-/**
  * Initialize the migrations schema and keep it up-to-date
  *
  * @return void


### PR DESCRIPTION
Whilst trying to understand how the the reset functionality worked, I came across some unused code.
