### PR TITLE
Remove assignment by reference

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -83,7 +83,7 @@ class MigrationShell extends AppShell {
 
 		$this->path = $this->_getPath() . 'Config' . DS . 'Migration' . DS;
 
-		$this->Version =& new MigrationVersion(array(
+		$this->Version = new MigrationVersion(array(
 			'precheck' => $this->params['precheck'],
 			'connection' => $this->connection,
 			'autoinit' => !$this->params['no-auto-init']));


### PR DESCRIPTION
Using the =& assignment by reference was deprecated in php 5.3+ . [http://www.php.net/manual/en/migration53.deprecated.php]()

On my setup (Ubuntu 13.04 & PHP 5.4.9-4ubuntu2 (cli)) cake shell throws a misleading error at the changed line:

"Fatal Error Error: Class 'ConsoleOutput' not found in [/vagrant/site_deploy/Plugin/Migrations/Console/Command/MigrationShell.php, line 86]"

I noticed this has been fixed in the develop branch. Just thought it might be helpful to others to add this quick fix before develop branch is ready.
