### PR TITLE
Fix clear

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -310,7 +310,7 @@ class MigrationShell extends AppShell {
 				if (strtolower($response) === 'q') {
 					return $this->_stop();
 				} else if (strtolower($response) === 'c') {
-					$this->_clear();
+					$this->clear();
 					continue;
 				}
 
@@ -490,15 +490,6 @@ class MigrationShell extends AppShell {
 				$this->out(__d('migrations', 'not applied'));
 			}
 		}
-	}
-
-/**
- * Clear the console
- *
- * @return void
- */
-	protected function _clear() {
-		$this->Dispatch->clear();
 	}
 
 /**


### PR DESCRIPTION
Dispatch property is not set and caused:

> PHP Fatal error:  Call to a member function clear() on a non-object in APP/Plugin/Migrations/Console/Command/MigrationShell.php on line 459

The feature that clears console is `clear()` method of `Shell` class since just 2.0.
