### PR TITLE
Fix for cake 2.4 schema compare when create is needed

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -471,7 +471,7 @@ class MigrationShell extends AppShell {
 	protected function _fromComparison($migration, $comparison, $oldTables, $currentTables) {
 		foreach ($comparison as $table => $actions) {
 			if (!isset($oldTables[$table])) {
-				$migration['up']['create_table'][$table] = $actions['add'];
+				$migration['up']['create_table'][$table] = $actions['create'];
 				$migration['down']['drop_table'][] = $table;
 				continue;
 			}


### PR DESCRIPTION
A Fix for Cakephp 2.4.

The CakeSchema compare method has been changed. Instead of key "add", key "create" is used. Because of these change the Migrations plugin cannot compare a CakeSchema when a new table must be created.
