### PR TITLE
Tweak travis file to fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
 before_script:
   - git clone --depth 1 --branch $CAKE_VERSION git://github.com/cakephp/cakephp ../cakephp && cd ../cakephp
   - cp -R ../migrations plugins/Migrations
-  - sh -c "mysql -e 'CREATE DATABASE cakephp_test;'"
+  - sh -c "mysql -e 'CREATE DATABASE cakephp_test COLLATE utf8_general_ci;'"
+  - sh -c "mysql -e 'CREATE DATABASE cakephp_default COLLATE utf8_general_ci;'"
   - echo "<?php
     class DATABASE_CONFIG {
     public \$test = array(
@@ -26,6 +27,16 @@ before_script:
       'host' => '0.0.0.0',
       'login' => 'travis',
       'persistent' => false,
+      'encoding' => 'utf8',
+    );
+
+    public \$default = array(
+      'datasource' => 'Database/Mysql',
+      'database' => 'cakephp_default',
+      'host' => '0.0.0.0',
+      'login' => 'travis',
+      'persistent' => false,
+      'encoding' => 'utf8',
     );
     }" > app/Config/database.php
   - cd app


### PR DESCRIPTION
There are 4 test which fail, only on Travis CI, on all existing branches - develop, master, etc. They pass when the tests are run locally. Two of the four failures are fixed by this tweak to the travis.yml file.

This follows on from the final comments at https://github.com/CakeDC/migrations/pull/148#issuecomment-35208432

I'm unable to figure out what is causing the failure in the other two tests, but you can see the failures at https://travis-ci.org/joshuapaling/migrations/jobs/19028060
