### PR TITLE
Prevent undefined index error rather than masking the actual error

### DIFF
--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -345,7 +345,13 @@ class MigrationVersion {
 					$this->log[$info['name']] = $migration->getQueryLog();
 				} catch (Exception $exception) {
 					$mapping = $this->getMapping($options['type']);
-					$latestVersionName = '#' . number_format($mapping[$latestVersion]['version'] / 100, 2, '', '') . ' ' . $mapping[$latestVersion]['name'];
+					if (isset($mapping[$latestVersion]['version'])) {
+						$latestVersionName = '#' .
+							number_format($mapping[$latestVersion]['version'] / 100, 2, '', '') . ' ' .
+							$mapping[$latestVersion]['name'];
+					} else {
+						$latestVersionName = null;
+					}
 					$errorMessage = __d('migrations', sprintf("There was an error during a migration. \n The error was: '%s' \n You must resolve the issue manually and try again.", $exception->getMessage(), $latestVersionName));
 					return $errorMessage;
 				}


### PR DESCRIPTION
This happens when you forgot to add `return true;` in `before()` or `after()`.

Even though this is PEBKAC, it obscures the actual error and killed a kitten everytime it happens.
