### PR TITLE
Fixed "Notice: Undefined variable: connection in plugins/migrations/libs/model/cake_migration.php on line 296".

### DIFF
--- a/libs/model/cake_migration.php
+++ b/libs/model/cake_migration.php
@@ -272,6 +272,8 @@ class CakeMigration extends Object {
  * @access protected
  */
 	function _alterTable($type, $tables) {
+		$connection = !empty($this->migration['connection']) ? $this->migration['connection'] : $this->connection;
+		
 		foreach ($tables as $table => $fields) {
 			$indexes = array();
 			if (isset($fields['indexes'])) {


### PR DESCRIPTION
57eea8f501011ad70f84f11205f781eca3697e42 has a bug.
When I run migration, an notice occurred.

```
PHP Notice:  Undefined variable: connection in /plugins/migrations/libs/model/cake_migration.php on line 296
```

It's because the variable `$connection* is not defined, cannot work to use a different db specified in the migration file for`alter table`.
I defined *$connection`.
