### PR TITLE
Bug/schema naming

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -760,7 +760,7 @@ class MigrationShell extends AppShell {
 		if ($this->params['force']) {
 			$command .= ' --force';
 		}
-		$command .= ' --name ' . $this->_getSchemaClassName($this->type, false);
+		$command .= ' --file schema.php --name ' . $this->_getSchemaClassName($this->type, false);
 		$this->dispatchShell($command);
 	}
 

--- a/Test/Case/Console/Command/MigrationShellTest.php
+++ b/Test/Case/Console/Command/MigrationShellTest.php
@@ -733,7 +733,7 @@ TEXT;
 		$this->Shell->expects($this->at(2))->method('in')->will($this->returnValue('n'));
 		$this->Shell->expects($this->at(3))->method('in')->will($this->returnValue('drop slug field'));
 		$this->Shell->expects($this->at(4))->method('in')->will($this->returnValue('y'));
-		$this->Shell->expects($this->at(5))->method('dispatchShell')->with('schema generate --connection test --force --name TestMigrationPlugin4');
+		$this->Shell->expects($this->at(5))->method('dispatchShell')->with('schema generate --connection test --force --file schema.php --name TestMigrationPlugin4');
 
 		$this->Shell->Version->expects($this->any())->method('getMapping')->will($this->returnCallback(array($this, 'returnMapping')));
 


### PR DESCRIPTION
Proposed fix for CakeDC/migrations#131.

Adds an option for specifying the Schema class name on the command line.

Updates `_getSchema()` and `_updateSchema()` to use a new `_getSchemaClassName()` method, which merges existing behavior for plugins with a new default for base Cake applications.

Most importantly, `Config/Schema/schema.php` files will now be generated using `AppSchema` as the default class name instead of `APP_DIR . 'Schema'`.

Thanks to @burzum for the initial attempt at resolving this.
