### PR TITLE
Removed cakephp dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
 	},
 	"require": {
 		"php": ">=5.2.8",
-		"cakephp/cakephp": ">=2.5.4,<3.0",
 		"composer/installers": "*"
 	}
 }


### PR DESCRIPTION
https://github.com/CakeDC/migrations/commit/14a3cc4b6168c50235ca42923d31796780f3be28#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R25

The change above unfortunately means that everyone who manages the CakePHP framework dependency manually (aka oldskool) and doesn't use Composer for that, will have CakePHP 2.5.5 installed side by side his already manually managed version.

Until now I could manage the CakePHP dependency manually while everything else could be managed through Composer.

I think not everybody is ready (or willing) yet to change his development workflow to let Composer manage the underlying framework for him.

I propose to remove that line and if it is really the way to go, then let's do that please in a minor release (e.g. Migrations 2.4) and not in a patch release...
