### PR TITLE
Fix for incorrect naming of all plugin migrations

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -159,7 +159,7 @@ class MigrationShell extends AppShell {
 			->addOption('schema-class', array(
 				'short' => 's',
 				'boolean' => false,
-				'default' => 'App',
+				'default' => false,
 				'help' => __('CamelCased Classname without the `Schema` suffix to use when reading or generating schema files. See `Console/cake schema generate --help`.')))
 			->addSubcommand('status', array(
 				'help' => __('Displays a status of all plugin and app migrations.')))


### PR DESCRIPTION
As default after the Oct 17 changes, the schema.php files will all have a class name of AppSchema instead of the plugin name.

The current only solution is to run your command as Console/cake Migrations.migration generate --plugin MyPlugin --schema-class  MyPlugin

This was not an issue in v 2.3.2, so this became an issue in 2.3.3 or above.