### PR TITLE
resolve javascript error for Debugkit Migrations panel

### DIFF
--- a/View/Elements/migrations_panel.ctp
+++ b/View/Elements/migrations_panel.ctp
@@ -62,46 +62,49 @@ if (document.getElementsByClassName == undefined) {
 		return results;
 	}
 }
+setTimeout(function() {
+    DEBUGKIT.$(document).ready(function () {
+        DEBUGKIT.module('migrationsPanel');
+        DEBUGKIT.migrationsPanel = function () {
+            var toolbar = DEBUGKIT.toolbar,
+                Element = DEBUGKIT.Util.Element,
+                Cookie = DEBUGKIT.Util.Cookie,
+                Collection = DEBUGKIT.Util.Collection,
+                Event = DEBUGKIT.Util.Event,
+                migrationsHidden = false;
 
-DEBUGKIT.module('migrationsPanel');
-DEBUGKIT.migrationsPanel = function () {
-	var toolbar = DEBUGKIT.toolbar,
-		Element = DEBUGKIT.Util.Element,
-		Cookie = DEBUGKIT.Util.Cookie,
-		Collection = DEBUGKIT.Util.Collection,
-		Event = DEBUGKIT.Util.Event,
-		migrationsHidden = false;
+            return {
+                init: function () {
+                    var button = document.getElementById('hide-migrations'),
+                        self = this;
 
-	return {
-		init: function () {
-			var button = document.getElementById('hide-migrations'),
-				self = this;
+                    Event.addEvent(button, 'click', function (event) {
+                        event.preventDefault();
+                        self.toggleMigrations();
+                    });
 
-			Event.addEvent(button, 'click', function (event) {
-				event.preventDefault();
-				self.toggleMigrations();
-			});
+                    var migrationsState = Cookie.read('migrationsDisplay');
+                    console.log(migrationsState);
+                    if (migrationsState != 'show') {
+                        migrationsHidden = false;
+                        this.toggleMigrations();
+                    }
+                },
 
-			var migrationsState = Cookie.read('migrationsDisplay');
-			console.log(migrationsState);
-			if (migrationsState != 'show') {
-				migrationsHidden = false;
-				this.toggleMigrations();
-			}
-		},
-
-		toggleMigrations: function () {
-			var display = migrationsHidden ? 'show' : 'hide';
-			var arr = document.getElementsByClassName("migration-applied");
-			for (i = 0; i < arr.length; i++) {
-				Element[display](arr[i]);
-			}
-			Cookie.write('migrationsDisplay', display);
-			migrationsHidden = !migrationsHidden;
-			return false;
-		}
-	};
-}();
-DEBUGKIT.loader.register(DEBUGKIT.migrationsPanel);
+                toggleMigrations: function () {
+                    var display = migrationsHidden ? 'show' : 'hide';
+                    var arr = document.getElementsByClassName("migration-applied");
+                    for (i = 0; i < arr.length; i++) {
+                        Element[display](arr[i]);
+                    }
+                    Cookie.write('migrationsDisplay', display);
+                    migrationsHidden = !migrationsHidden;
+                    return false;
+                }
+            };
+        }();
+        DEBUGKIT.loader.register(DEBUGKIT.migrationsPanel);
+    });
+}, 0);
 //]]>
 </script>


### PR DESCRIPTION
Migrations panel for Debugkit causes Javascript error because undefined object DEBUGKIT.Util is referred.
In Debugkit source code, Debugkit.Util and all other module object are initialized in DEBUGKIT.$(document).ready() called from setTimeout.

https://github.com/cakephp/debug_kit/blob/2.2/webroot/js/js_debug_toolbar.js#L72

So, Migrations panel should be initialized after DEBUGKIT.Util is initialized.
