### PR TITLE
Hotfix/precheck not found

### DIFF
--- a/Lib/CakeMigration.php
+++ b/Lib/CakeMigration.php
@@ -196,10 +196,9 @@ class CakeMigration extends Object {
 			App::uses('PrecheckException', 'Migrations.Lib/Migration');
 			$this->Precheck = new PrecheckException();
 		} else {
-			$class = Inflector::camelize($options['precheck']);
-			list($plugin, $class) = pluginSplit($class, true);
+			list($plugin, $class) = pluginSplit($options['precheck'], true);
+			$class = Inflector::camelize($class);
 			App::uses($class, $plugin . 'Lib/Migration');
-
 			if (!class_exists($class)) {
 				throw new MigrationException($this, sprintf(
 					__d('migrations', 'Migration precheck class (%s) could not be loaded.'), $options['precheck']

--- a/Test/Case/Console/Command/MigrationShellTest.php
+++ b/Test/Case/Console/Command/MigrationShellTest.php
@@ -957,12 +957,12 @@ TEXT;
 /Migrations Plugin
 
 Current version:
-  #003 003_increase_class_name_length
+  #002 002_convert_version_to_class_names
 Latest version:
   #003 003_increase_class_name_length/
 TEXT;
 		$this->assertRegExp(str_replace("\r\n", "\n", $pattern), $result);
-		$this->Shell->Version->setVersion(3, 'migrations', false);
+		$this->Shell->Version->setVersion(2, 'migrations', false);
 		$this->Shell->output = '';
 		$this->Shell->args = array('outdated');
 		$this->Shell->status();
@@ -971,7 +971,7 @@ TEXT;
 /Migrations Plugin
 
 Current version:
-  #002 002_convert_version_to_class_names
+  #001 001_init_migrations
 Latest version:
   #003 003_increase_class_name_length/
 TEXT;


### PR DESCRIPTION
fixed tests locally and fixed the "precheck class not found" issue after inflector changes in CakePHP 2.6.6