### PR TITLE
Validate migrateConnection argument when a custom connection is setted

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -23,6 +23,10 @@ App::uses('ClassRegistry', 'Utility');
 class MigrationShell extends AppShell {
 
 /**
+ * Call the ConnectionManager Model
+ */
+	public $uses = ['ConnectionManager'];
+/**
  * Connection used for the migration_schema table of the migration versions
  *
  * @var null|string
@@ -79,9 +83,7 @@ class MigrationShell extends AppShell {
 			$this->connection = $this->params['connection'];
 		}
 
-		if (!empty($this->params['migrationConnection'])) {
-			$this->migrationConnection = $this->params['migrationConnection'];
-		}
+		$this->migrationConnection = $this->_startMigrationConnection();
 
 		if (!empty($this->params['plugin'])) {
 			$this->type = $this->params['plugin'];
@@ -115,6 +117,30 @@ class MigrationShell extends AppShell {
 			'add_index' => __d('migrations', 'Adding index ":index" to table ":table".'),
 			'drop_index' => __d('migrations', 'Dropping index ":index" from table ":table".'),
 		);
+	}
+
+/**
+ * Get connection names list
+ * @return Array
+ */
+	protected function _connectionNamesEnum(){
+		return array_keys($this->ConnectionManager->enumConnectionObjects());
+	}
+
+/**
+ * Check if have a migration connect parameter when connection is custom
+ * @return String
+ */
+	protected function _startMigrationConnection(){
+		if (!empty($this->params['connection']) && empty($this->params['migrationConnection'])) {
+				$this->migrationConnection = $this->in(
+					"You did not set a migration connection (-i), which do you will use?",
+					$this->_connectionNamesEnum(),
+					$this->params['connection']
+				);
+		}
+
+		return $this->params['migrationConnection'];
 	}
 
 /**

--- a/Test/Case/Console/Command/MigrationShellTest.php
+++ b/Test/Case/Console/Command/MigrationShellTest.php
@@ -162,6 +162,7 @@ class MigrationShellTest extends CakeTestCase {
 		$this->assertEquals($this->Shell->type, 'TestMigrationPlugin');
 		$this->Shell->params = array(
 			'connection' => 'test',
+			'migrationConnection' => 'test',
 			'plugin' => 'Migrations',
 			'no-auto-init' => false,
 			'dry' => false,


### PR DESCRIPTION
That will fix this issue https://github.com/CakeDC/migrations/issues/212 it's a bug I guess, not a feature how he told in the issue.
Tnx guys