### PR TITLE
Some minor formatting and date related improvements

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -705,7 +705,7 @@ class MigrationShell extends AppShell {
 		if ($version != 0) {
 			$info = $mapping[$version];
 			$this->out(__d('migrations', 'Current migration version:'));
-			$this->out('  #' . number_format($version / 100, 2, '', '') . '  ' . $info['name']);
+			$this->out('  #' . number_format($version / 100, 2, '', '') . ' ' . $info['name']);
 			$this->hr();
 		}
 

--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -18,6 +18,7 @@ App::uses('ClassRegistry', 'Utility');
 App::uses('ConnectionManager', 'Model');
 App::uses('Folder', 'Utility');
 App::uses('File', 'Utility');
+App::uses('CakeTime', 'Utility');
 
 /**
  * Migration shell.
@@ -715,7 +716,7 @@ class MigrationShell extends AppShell {
 
 			$this->out('        ', false);
 			if ($info['migrated'] !== null) {
-				$this->out(__d('migrations', 'applied') . ' ' . date('r', strtotime($info['migrated'])));
+				$this->out(__d('migrations', 'applied') . ' ' . CakeTime::nice(strtotime($info['migrated'])));
 			} else {
 				$this->out(__d('migrations', 'not applied'));
 			}

--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -675,13 +675,13 @@ class MigrationShell extends AppShell {
 				$this->out(__d('migrations', 'Current version:'));
 				if ($version != 0) {
 					$info = $mapping[$version];
-					$this->out('  #' . number_format($info['version'] / 100, 2, '', '') . ' ' . $info['name']);
+					$this->out('  #' . sprintf("%'.03d", $info['version']) . ' ' . $info['name']);
 				} else {
 					$this->out('  ' . __d('migrations', 'None applied.'));
 				}
 
 				$this->out(__d('migrations', 'Latest version:'));
-				$this->out('  #' . number_format($latest['version'] / 100, 2, '', '') . ' ' . $latest['name']);
+				$this->out('  #' . sprintf("%'.03d", $latest['version']) . ' ' . $latest['name']);
 				$this->hr();
 			} catch (MigrationVersionException $e) {
 				continue;
@@ -705,13 +705,13 @@ class MigrationShell extends AppShell {
 		if ($version != 0) {
 			$info = $mapping[$version];
 			$this->out(__d('migrations', 'Current migration version:'));
-			$this->out('  #' . number_format($version / 100, 2, '', '') . ' ' . $info['name']);
+			$this->out('  #' . sprintf("%'.03d", $version) . ' ' . $info['name']);
 			$this->hr();
 		}
 
 		$this->out(__d('migrations', 'Available migrations:'));
 		foreach ($mapping as $version => $info) {
-			$this->out('  [' . number_format($version / 100, 2, '', '') . '] ' . $info['name']);
+			$this->out('  [' . sprintf("%'.03d", $version) . '] ' . $info['name']);
 
 			$this->out('        ', false);
 			if ($info['migrated'] !== null) {
@@ -1206,7 +1206,7 @@ class MigrationShell extends AppShell {
  * @return void
  */
 	public function beforeMigration(&$Migration, $direction) {
-		$this->out('  [' . number_format($Migration->info['version'] / 100, 2, '', '') . '] ' . $Migration->info['name']);
+		$this->out('  [' . sprintf("%'.03d", $Migration->info['version']) . '] ' . $Migration->info['name']);
 	}
 
 /**

--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -1202,12 +1202,21 @@ class MigrationShell extends AppShell {
 /**
  * Callback used to display what migration is being runned
  *
+ * Additionally, shows the generation date of the migration,
+ * if the version is greater than '2000-01-01'.
+ *
  * @param CakeMigration &$Migration Migration being performed
  * @param string $direction Direction being runned
  * @return void
  */
 	public function beforeMigration(&$Migration, $direction) {
-		$this->out('  [' . sprintf("%'.03d", $Migration->info['version']) . '] ' . $Migration->info['name']);
+		$version = $Migration->info['version'];
+		$generationDate = '';
+		if ($version > 946684800) {
+			$generationDate =  ' (' .	CakeTime::format($version, '%Y-%m-%d %H:%M:%S') . ')';
+		}
+		$this->out('  [' . sprintf("%'.03d", $version) . '] ' . $Migration->info['name'] . $generationDate
+		);
 	}
 
 /**

--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -343,7 +343,7 @@ class MigrationVersion {
 					$mapping = $this->getMapping($options['type']);
 					if (isset($mapping[$latestVersion]['version'])) {
 						$latestVersionName = '#' .
-							number_format($mapping[$latestVersion]['version'] / 100, 2, '', '') . ' ' .
+							sprintf("%'.03d", $mapping[$latestVersion]['version']) . ' ' .
 							$mapping[$latestVersion]['name'];
 					} else {
 						$latestVersionName = null;

--- a/Test/Case/Lib/MigrationVersionTest.php
+++ b/Test/Case/Lib/MigrationVersionTest.php
@@ -12,6 +12,7 @@
 App::uses('CakeMigration', 'Migrations.Lib');
 App::uses('CakeSchema', 'Model');
 App::uses('MigrationVersion', 'Migrations.Lib');
+App::uses('CakeTime', 'Utility');
 
 class MigrationVersionTest extends CakeTestCase {
 
@@ -323,7 +324,7 @@ class MigrationVersionTest extends CakeTestCase {
 				'type' => 'mocks', 'migrated' => null
 			);
 			if ($i >= $start && $i <= $end) {
-				$mapping[$i]['migrated'] = date('r');
+				$mapping[$i]['migrated'] = CakeTime::nice();
 			}
 		}
 		return $mapping;


### PR DESCRIPTION
The shell shows now:

````
Cake Migration Shell
---------------------------------------------------------------
Running migrations:
  [1443110827] 1443110827_enlarge_name_field (2015-09-24 18:07:07)
      > Changing field "name" from table "articles".

  [1443109776] 1443109776_add_price_to_articles (2015-09-24 17:49:36)
      > Dropping field "price" from table "articles".

  [1443109711] 1443109711_create_articles_table (2015-09-24 17:48:31)
      > Dropping table "articles".

---------------------------------------------------------------
All migrations have completed.
````

Notice the info when the migration was generated.