### PR TITLE
Add a proxy class to use the new CakePHP 2.7.x shell shortcut feature

### DIFF
--- a/Console/Command/MigrationsShell.php
+++ b/Console/Command/MigrationsShell.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright 2009 - 2014, Cake Development Corporation (http://cakedc.com)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright 2009 - 2014, Cake Development Corporation (http://cakedc.com)
+ * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+App::uses('MigrationShell', 'Migrations.Console/Command');
+
+/**
+ * Migrations shell
+ *
+ * A proxy class to use the new CakePHP 2.7.x shell shortcut feature.
+ */
+class MigrationsShell extends MigrationShell {}


### PR DESCRIPTION
Refs: http://book.cakephp.org/2.0/en/appendices/2-7-migration-guide.html#console