### PR TITLE
Remove pointless i18n call

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -267,7 +267,7 @@ class MigrationShell extends AppShell {
 
 		$result = $this->_execute($options, $once);
 		if ($result !== true) {
-			$this->out(__d('migrations', $result));
+			$this->out($result);
 		}
 
 		$this->out(__d('migrations', 'All migrations have completed.'));


### PR DESCRIPTION
Fixes: 

````
Invalid marker content in D:\dev\xampp\htdocs\barakuda\app\Plugin\Migrations\Console\Command\MigrationShell.php:243
* __d(
'migrations',$result)
````