### PR TITLE
Remove duplicated sprintf in i18n call

### DIFF
--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -349,7 +349,7 @@ class MigrationVersion {
 					} else {
 						$latestVersionName = null;
 					}
-					$errorMessage = __d('migrations', sprintf("There was an error during a migration. \n The error was: '%s' \n You must resolve the issue manually and try again.", $exception->getMessage(), $latestVersionName));
+					$errorMessage = __d('migrations', "There was an error during a migration. \n The error was: '%s' \n You must resolve the issue manually and try again.", $exception->getMessage(), $latestVersionName);
 					return $errorMessage;
 				}
 


### PR DESCRIPTION
Fixes:
````
Invalid marker content in D:\dev\xampp\htdocs\barakuda\app\Plugin\Migrations\Lib\MigrationVersion.php:352
* __d(
'migrations',sprintf("There was an error during a migration. \n The error was: '%s' \n You must resolve the issue manually and try again.",$exception->getMessage(),$latestVersionName))
````

http://book.cakephp.org/2.0/en/core-libraries/global-constants-and-functions.html#__d