### PR TITLE
Migration generation doesn't detect drop tables only changes

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -427,7 +427,7 @@ class MigrationShell extends AppShell {
 				$response = $this->in(__d('migrations', 'Do you want to compare the schema.php file to the database?'), array('y', 'n'), 'y');
 				if (strtolower($response) === 'y') {
 					$this->_generateFromComparison($migration, $oldSchema, $comparison);
-					if (empty($comparison)) {
+					if (empty($migration)) {
 						$this->hr();
 						$this->out(__d('migrations', 'No database changes detected.'));
 						return $this->_stop();


### PR DESCRIPTION
https://github.com/CakeDC/migrations/issues/210

`CakeSchema.php` is processing based on the new schema definition.
`drop table` does not include in the new schema.