### PR TITLE
Revert "Migration generation doesn't detect drop tables only changes"

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -427,7 +427,7 @@ class MigrationShell extends AppShell {
 				$response = $this->in(__d('migrations', 'Do you want to compare the schema.php file to the database?'), array('y', 'n'), 'y');
 				if (strtolower($response) === 'y') {
 					$this->_generateFromComparison($migration, $oldSchema, $comparison);
-					if (empty($migration)) {
+					if (empty($comparison)) {
 						$this->hr();
 						$this->out(__d('migrations', 'No database changes detected.'));
 						return $this->_stop();


### PR DESCRIPTION
Reverts CakeDC/migrations#240