### PR TITLE
Fix processing nested associative array

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -1156,7 +1156,12 @@ class MigrationShell extends AppShell {
 		if (is_array($values)) {
 			foreach ($values as $key => $value) {
 				if (is_array($value)) {
-					$_values[] = "'" . $key . "' => array('" . implode("', '", $value) . "')";
+					if (array_keys($value) !== range(0, count($value) - 1)) {
+						$set = implode("', '", $this->_values($value));
+					} else {
+						$set = "'" . implode("', '", $value) . "'";
+					}
+					$_values[] = "'" . $key . "' => array(" . $set . ")";
 				} elseif (!is_numeric($key)) {
 					$value = var_export($value, true);
 					$_values[] = "'" . $key . "' => " . $value;


### PR DESCRIPTION
This fixes issue #196 by allowing an index's value for `length` to be an associative array. Example:

Whereas the plugin previously generated this, which caused a MySQL error:
```
'indexes' => array(
    'PRIMARY' => array('column' => 'id', 'unique' => 1),
    'unique_name' => array('column' => 'name', 'unique' => 1, 'length' => array('100')),
),
```

It now generates this:
```
'indexes' => array(
    'PRIMARY' => array('column' => 'id', 'unique' => 1),
    'unique_name' => array('column' => 'name', 'unique' => 1, 'length' => array('name' => '100')),
),
```