### PR TITLE
Updated to match the rest of the docs

### DIFF
--- a/Docs/Home.md
+++ b/Docs/Home.md
@@ -6,8 +6,8 @@ This **Migrations** plugin enables developers to quickly and easily manage and m
 Requirements
 ------------
 
-* CakePHP 2.5+
-* PHP 5.2.8+
+* CakePHP 2.7+
+* PHP 5.3+
 
 Documentation
 -------------


### PR DESCRIPTION
On https://github.com/CakeDC/migrations its specified that the plugin now needs CakePHP 2.7+ and PHP 5.3+ so just a quick update to reflect that on the docs home.