### PR TITLE
Fix Requirements version numbers not matching with README

### DIFF
--- a/Docs/Home.md
+++ b/Docs/Home.md
@@ -6,8 +6,8 @@ This **Migrations** plugin enables developers to quickly and easily manage and m
 Requirements
 ------------
 
-* CakePHP 2.5+
-* PHP 5.2.8+
+* CakePHP 2.7.0+
+* PHP 5.3.0+
 
 Documentation
 -------------


### PR DESCRIPTION
The version numbers of the Requirements on the Docs/Home page are older than those on the README. I updated the Home page version numbers.