### PR TITLE
Fix that "No database changes detected." was not reachable

### DIFF
--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -484,13 +484,13 @@ class MigrationShell extends AppShell {
 
 				if (strtolower($response) === 'y') {
 					$this->_generateFromComparison($migration, $oldSchema, $comparison);
-					$this->_migrationChanges($migration);
+					$this->_checkNoMigrationChanges($migration);
 					$fromSchema = true;
 				} else {
 					$response = $this->in(__d('migrations', 'Do you want to compare the database to the schema.php file?'), array('y', 'n'), 'y');
 					if (strtolower($response) === 'y') {
 						$this->_generateFromInverseComparison($migration, $oldSchema, $comparison);
-						$this->_migrationChanges($migration);
+						$this->_checkNoMigrationChanges($migration);
 						$fromSchema = false;
 					}
 				}
@@ -518,16 +518,18 @@ class MigrationShell extends AppShell {
 	}
 
 /**
- * _migrationsChanges method
+ * Check whether there are migration changes
  *
  * @param array $migration list of migrations
- * @return bool
+ * @return void
  */
-	protected function _migrationChanges($migration) {
-		if (empty($migration)) {
+	protected function _checkNoMigrationChanges($migration) {
+		if (empty($migration) ||
+            (empty($migration['up']) && empty($migration['down']))) {
 			$this->hr();
 			$this->out(__d('migrations', 'No database changes detected.'));
-			return $this->_stop();
+			$this->_stop();
+            return;
 		}
 	}
 


### PR DESCRIPTION
Due to setting up a half empty array [here](https://github.com/CakeDC/migrations/blob/e41c7d292758dd67f1833203f35a7dd251f12a32/Console/Command/MigrationShell.php#L449), the check for an empty migration array was never reached [here](https://github.com/CakeDC/migrations/blob/e41c7d292758dd67f1833203f35a7dd251f12a32/Console/Command/MigrationShell.php#L501-L513).

I guess a better test coverage for this case could prevent future regressions.