### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,14 @@ Changelog
 Release 2.5.1
 -------------
 
-* [955e10b3](https://github.com/CakeDC/migrations/commit/955e10b3) fix phpdo
-* [7d9b053](https://github.com/CakeDC/migrations/commit/7d9b053a6) Missing note about the schema/database comparison.
-* [7b47ae3](https://github.com/CakeDC/migrations/commit/7b47ae3) Updating the docs.
-* [a59d1d1](https://github.com/CakeDC/migrations/commit/a59d1d1) Fix missing return statements.
-* [9363915](https://github.com/CakeDC/migrations/commit/9363915) Migration name check.
-* [263c739](https://github.com/CakeDC/migrations/commit/263c739) New preview options.
-* [0a4dc0b](https://github.com/CakeDC/migrations/commit/0a4dc0b) Fix missing translation domain.
-* [dfbed18](https://github.com/CakeDC/migrations/commit/dfbed18) New name param.
-
+* [dfbed18](https://github.com/CakeDC/migrations/commit/dfbed18) New migration name CLI parameter
+* [955e10b3](https://github.com/CakeDC/migrations/commit/955e10b3) Fix doc block
+* [7d9b053](https://github.com/CakeDC/migrations/commit/7d9b053a6) Missing note about the schema/database comparison
+* [7b47ae3](https://github.com/CakeDC/migrations/commit/7b47ae3) Updating the docs
+* [a59d1d1](https://github.com/CakeDC/migrations/commit/a59d1d1) Fix missing return statements
+* [9363915](https://github.com/CakeDC/migrations/commit/9363915) Migration name check
+* [263c739](https://github.com/CakeDC/migrations/commit/263c739) New preview options
+* [0a4dc0b](https://github.com/CakeDC/migrations/commit/0a4dc0b) Fix missing translation domain
 
 Release 2.5.0
 -------------

--- a/Console/Command/MigrationShell.php
+++ b/Console/Command/MigrationShell.php
@@ -484,13 +484,13 @@ class MigrationShell extends AppShell {
 
 				if (strtolower($response) === 'y') {
 					$this->_generateFromComparison($migration, $oldSchema, $comparison);
-					$this->_migrationChanges($migration);
+					$this->_checkNoMigrationChanges($migration);
 					$fromSchema = true;
 				} else {
 					$response = $this->in(__d('migrations', 'Do you want to compare the database to the schema.php file?'), array('y', 'n'), 'y');
 					if (strtolower($response) === 'y') {
 						$this->_generateFromInverseComparison($migration, $oldSchema, $comparison);
-						$this->_migrationChanges($migration);
+						$this->_checkNoMigrationChanges($migration);
 						$fromSchema = false;
 					}
 				}
@@ -518,16 +518,18 @@ class MigrationShell extends AppShell {
 	}
 
 /**
- * _migrationsChanges method
+ * Check whether there are migration changes
  *
  * @param array $migration list of migrations
- * @return bool
+ * @return void
  */
-	protected function _migrationChanges($migration) {
-		if (empty($migration)) {
+	protected function _checkNoMigrationChanges($migration) {
+		if (empty($migration) ||
+            (empty($migration['up']) && empty($migration['down']))) {
 			$this->hr();
 			$this->out(__d('migrations', 'No database changes detected.'));
-			return $this->_stop();
+			$this->_stop();
+            return;
 		}
 	}
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ However, you can make use of the ```before()``` and ```after()``` callbacks in t
 Requirements
 ------------
 
-* CakePHP 2.5+ (We recomment latest 2.x)
+* CakePHP 2.5+ (We recommend latest 2.x)
 * PHP 5.3.0+ (We recommend php 7+)
 
 Documentation


### PR DESCRIPTION
Hi !
In Cakephp 2.9.0+, "Object" was replaced by "CakeObject" for php 7+ compatibility.
You need to replace in Migrations/Lib/CakeMigration.php :

`class CakeMigration extends Object {`

by

`class CakeMigration extends CakeObject {`

:)