### PR TITLE
Update composer require version number

### DIFF
--- a/Docs/Documentation/Installation.md
+++ b/Docs/Documentation/Installation.md
@@ -42,5 +42,5 @@ Composer
 To install the plugin with the [Composer dependency manager](https://getcomposer.org/), run the following from your CakePHP project's ROOT directory (where the ``composer.json`` file is located):
 
 ```
-php composer.phar require cakedc/migrations "~2.4.0"
+php composer.phar require cakedc/migrations "^2.6.0"
 ```


### PR DESCRIPTION
Update desirable since v2.4 contains a breaking change with CakePHP and PHP >= 7.2 and users will copy/paste this code without altering it.