### PR TITLE
PHP 7.2+ compatibility

### DIFF
--- a/Lib/MigrationVersion.php
+++ b/Lib/MigrationVersion.php
@@ -252,7 +252,8 @@ class MigrationVersion {
 
 		ksort($mapping);
 		foreach ($mapping as $version => $migration) {
-			list($name, $class) = each($migration);
+			$class = reset($migration);
+            		$name = key($migration);
 
 			$mapping[$version] = array(
 				'version' => $version, 'name' => $name, 'class' => $class,
@@ -439,7 +440,8 @@ class MigrationVersion {
 		if (!in_array($db->fullTableName('schema_migrations', false, false), $db->listSources())) {
 			$map = $this->_enumerateMigrations('migrations');
 
-			list($name, $class) = each($map[1]);
+			$class = reset($map[1]);
+            		$name = key($map[1]);
 			$migration = $this->getMigration($name, $class, 'Migrations');
 			$migration->run('up');
 			$this->setVersion(1, 'Migrations');


### PR DESCRIPTION
Hi !
With PHP 7.2+ there are deprecated warning when running migrations command line because of each() function.

Function each() is deprecated since PHP 7.2 and will be removed in PHP 8.0.
Replaced each() function by an equivalent so there are no more deprecation errors when running the migration command line.

Tested with PHP 7.4.25, CakePHP 2.10.24